### PR TITLE
fix URI handling on windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,19 @@ func fileUri(path string) string {
 	if err != nil {
 		log.Fatalf("%s: %s", path, err)
 	}
-	return "file://" + abs
+
+	uri := "file://"
+
+	if runtime.GOOS == "windows" {
+		uri = uri + "/" + strings.ReplaceAll(
+			strings.ReplaceAll(abs, "\\", "/"),
+			" ", "%20",
+		)
+	} else {
+		uri = uri + abs
+	}
+
+	return uri
 }
 
 // glob is a wrapper that also resolves `~` since we may be skipping

--- a/main.go
+++ b/main.go
@@ -187,6 +187,9 @@ func fileUri(path string) string {
 	uri := "file://"
 
 	if runtime.GOOS == "windows" {
+		// This is not formally correct for all corner cases in windows
+		// file handling but should work for all standard cases. See:
+		// https://docs.microsoft.com/en-us/archive/blogs/ie/file-uris-in-windows
 		uri = uri + "/" + strings.ReplaceAll(
 			strings.ReplaceAll(abs, "\\", "/"),
 			" ", "%20",


### PR DESCRIPTION
URI handling of filenames on windows is broken so the tool is  unusable on windows. This bugfix closes https://github.com/neilpa/yajsv/issues/1

This fix is probably not formally correct for all corner cases in windows file handling but should work for all standard cases.